### PR TITLE
redis branch v2.8.7 is not available. changed to version 3.0

### DIFF
--- a/redis-cli/Dockerfile
+++ b/redis-cli/Dockerfile
@@ -5,7 +5,7 @@ run apt-get update
 run apt-get install -yq git build-essential tcl8.5
 
 # install redis CLI
-run git clone -b v2.8.7 https://github.com/antirez/redis.git
+run git clone -b v3.0 https://github.com/antirez/redis.git
 run cd redis && make install redis-cli /usr/bin
 
 entrypoint  ["redis-cli"]


### PR DESCRIPTION
redis branch v2.8.7 is not available. changed to version 3.0
